### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main_chatgpt-6794121759f081918ff2ac717defa01femp.yml
+++ b/.github/workflows/main_chatgpt-6794121759f081918ff2ac717defa01femp.yml
@@ -4,6 +4,9 @@
 
 name: Build and deploy Python app to Azure Web App - chatgpt-6794121759f081918ff2ac717defa01femp
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -42,6 +45,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: 'Production'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Este proyecto tiene como objetivo desarrollar un asistente conversacional basado
 
 ## Colaboradores
 
-- [Tu nombre aquí]
-- [Agrega más colaboradores]
+- [Andres Maqueo]
+
 
 ## Licencia
 


### PR DESCRIPTION
Potential fix for [https://github.com/AndresMaqueo/av-is-aviable/security/code-scanning/3](https://github.com/AndresMaqueo/av-is-aviable/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `id-token: write` if required for authentication with Azure (though this is not explicitly mentioned in the workflow).
- Additional permissions can be added as needed for specific steps, such as `actions: write` or `pull-requests: write`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
